### PR TITLE
Adding a .Pages attribute in PdfWriter to allow setting its MediaBox or Resources fields

### DIFF
--- a/pdfrw/pdfwriter.py
+++ b/pdfrw/pdfwriter.py
@@ -138,7 +138,7 @@ def FormatObjects(f, trailer, version='1.3', compress=True, killobj=(),
                     if compress and obj.stream:
                         do_compress([obj])
                     pairs = sorted((getattr(x, 'encoded', None) or x, y)
-                                   for (x, y) in obj.iteritems())
+                                   for (x, y) in iteritems(obj))
                     myarray = []
                     for key, value in pairs:
                         myarray.append(key)
@@ -262,6 +262,7 @@ class PdfWriter(object):
                                      "on PdfWriter instance" % name)
                 setattr(self, name, value)
 
+        self.Pages = None
         self.pagearray = PdfArray()
         self.killobj = {}
 
@@ -310,14 +311,14 @@ class PdfWriter(object):
             self.make_canonical()
 
         # Create the basic object structure of the PDF file
+        pages = self.Pages or IndirectPdfDict()
+        pages.Type = PdfName.Pages
+        pages.Count = PdfObject(len(self.pagearray))
+        pages.Kids = self.pagearray
         trailer = PdfDict(
             Root=IndirectPdfDict(
                 Type=PdfName.Catalog,
-                Pages=IndirectPdfDict(
-                    Type=PdfName.Pages,
-                    Count=PdfObject(len(self.pagearray)),
-                    Kids=self.pagearray
-                )
+                Pages=pages,
             )
         )
         # Make all the pages point back to the page dictionary and

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -94,7 +94,7 @@ class TestOnePdf(unittest.TestCase):
                     os.remove(dstf)
                 if scrub and os.path.exists(scrub):
                     os.remove(scrub)
-                subprocess.call(params)
+                subprocess.check_output(params)
                 if scrub:
                     PdfWriter(dstf).addpages(PdfReader(scrub).pages).write()
             with open(dstf, 'rb') as f:
@@ -109,7 +109,7 @@ class TestOnePdf(unittest.TestCase):
             if expects:
                 if len(expects) == 1:
                     expects, = expects
-                    self.assertEqual(hash, expects)
+                    self.assertEqual(hash, expects, '{} file does not have the expected MD5 hash'.format(dstf))
                 else:
                     self.assertIn(hash, expects)
                 result = 'pass'

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -109,7 +109,8 @@ class TestOnePdf(unittest.TestCase):
             if expects:
                 if len(expects) == 1:
                     expects, = expects
-                    self.assertEqual(hash, expects, '{} file does not have the expected MD5 hash'.format(dstf))
+                    assert_error_msg = '{} file does not have the expected MD5 hash'.format(dstf)
+                    self.assertEqual(hash, expects, assert_error_msg)
                 else:
                     self.assertIn(hash, expects)
                 result = 'pass'

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -91,7 +91,7 @@ class TestOnePdf(unittest.TestCase):
             if expects:
                 if len(expects) == 1:
                     expects, = expects
-                    self.assertEqual(hash, expects)
+                    self.assertEqual(hash, expects, '{} file does not have the expected MD5 hash'.format(dstf))
                 else:
                     self.assertIn(hash, expects)
                 result = 'pass'

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -91,7 +91,8 @@ class TestOnePdf(unittest.TestCase):
             if expects:
                 if len(expects) == 1:
                     expects, = expects
-                    self.assertEqual(hash, expects, '{} file does not have the expected MD5 hash'.format(dstf))
+                    assert_error_msg = '{} file does not have the expected MD5 hash'.format(dstf)
+                    self.assertEqual(hash, expects, assert_error_msg)
                 else:
                     self.assertIn(hash, expects)
                 result = 'pass'


### PR DESCRIPTION
This allows for the following usage:
```python
out = PdfWriter()
out.Pages = IndirectPdfDict(
    MediaBox=...,
    Resources=...,
)
out.addpage(page)
out.write(...)
```

This is a copy of https://github.com/pmaupin/pdfrw/pull/205