### PR TITLE
replace asserts with helper funcs, cleanup more lint

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,0 +1,22 @@
+name: Security check - Bandit
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Run bandit
+      uses: VCTLabs/bandit-report-artifacts@master
+      with:
+        project_path: pdfrw
+        config_file: pyproject.toml
+        ignore_failure: false

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -39,7 +39,7 @@ jobs:
         echo "branch=${EXPORT_VALUE}" >> $GITHUB_OUTPUT
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  push:
+    # release on tag push
+    tags:
+      - '*'
+
+jobs:
+  packaging:
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      PYTHONIOENCODING: utf-8
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+
+    steps:
+    - name: Set git crlf/eol
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install tox tox-gh-actions
+
+    - name: Build dist pkgs
+      run: |
+        tox -e build
+
+    - name: Upload artifacts
+      if: matrix.python-version == 3.7 && runner.os == 'Linux'
+      uses: actions/upload-artifact@v3
+      with:
+        name: packages
+        path: ./dist/pdfrw-*
+
+  create_release:
+    name: Create Release
+    needs: [packaging]
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Get version
+        id: get_version
+        run: |
+          echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo ${{ env.VERSION }}
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # download all artifacts to project dir
+      - uses: actions/download-artifact@v3
+
+      - name: Generate changes file
+        uses: sarnold/gitchangelog-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN}}
+
+      - name: Create release
+        id: create_release
+        # this action needs an upgrade when available; get some fixes now
+        # using master or reset to v1 and let dependabot check
+        uses: softprops/action-gh-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          body_path: CHANGES.md
+          draft: false
+          prerelease: false
+          files: |
+            packages/pdfrw-*

--- a/README.rst
+++ b/README.rst
@@ -828,16 +828,16 @@ Revisions:
     :target: https://github.com/sarnold/pdfrw/actions/workflows/coverage.yml
     :alt: Coverage Status
 
-.. |badge| image:: https://github.com/sarnold/pyserv/actions/workflows/pylint.yml/badge.svg
-    :target: https://github.com/sarnold/pyserv/actions/workflows/pylint.yml
+.. |badge| image:: https://github.com/sarnold/pdfrw/actions/workflows/pylint.yml/badge.svg
+    :target: https://github.com/sarnold/pdfrw/actions/workflows/pylint.yml
     :alt: Pylint Status
 
 .. |cov| image:: https://raw.githubusercontent.com/sarnold/pdfrw/badges/master/test-coverage.svg
     :target: https://github.com/sarnold/pdfrw/
     :alt: Test coverage
 
-.. |pylint| image:: https://raw.githubusercontent.com/sarnold/pyserv/badges/master/pylint-score.svg
-    :target: https://github.com/sarnold/pyserv/actions/workflows/pylint.yml
+.. |pylint| image:: https://raw.githubusercontent.com/sarnold/pdfrw/badges/master/pylint-score.svg
+    :target: https://github.com/sarnold/pdfrw/actions/workflows/pylint.yml
     :alt: Pylint score
 
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 pdfrw 0.4-2
 ==================
 
-|ci| |coverage|
+|ci| |coverage| |bandit| |release|
 
 |cov| |pylint|
 
@@ -831,6 +831,14 @@ Revisions:
 .. |badge| image:: https://github.com/sarnold/pdfrw/actions/workflows/pylint.yml/badge.svg
     :target: https://github.com/sarnold/pdfrw/actions/workflows/pylint.yml
     :alt: Pylint Status
+
+.. |bandit| image:: https://github.com/sarnold/pdfrw/actions/workflows/bandit.yml/badge.svg
+    :target: https://github.com/sarnold/pdfrw/actions/workflows/bandit.yml
+    :alt: Security check - Bandit
+
+.. |release| image:: https://github.com/sarnold/pdfrw/actions/workflows/release.yml/badge.svg
+    :target: https://github.com/sarnold/pdfrw/actions/workflows/release.yml
+    :alt: Release Status
 
 .. |cov| image:: https://raw.githubusercontent.com/sarnold/pdfrw/badges/master/test-coverage.svg
     :target: https://github.com/sarnold/pdfrw/

--- a/pdfrw/__init__.py
+++ b/pdfrw/__init__.py
@@ -5,7 +5,7 @@
 PDF file reader/writer library
 """
 
-from ._version import __version__
+import pdfrw._version
 from .errors import PdfParseError
 from .objects import (
     IndirectPdfDict,
@@ -25,6 +25,20 @@ from .tokens import PdfTokens
 PdfFileReader = PdfReader
 PdfFileWriter = PdfWriter
 
-__all__ = """PdfWriter PdfReader PdfObject PdfName PdfArray
-             PdfTokens PdfParseError PdfDict IndirectPdfDict
-             PdfString PageMerge __version__""".split()
+__all__ = [
+    "PdfWriter",
+    "PdfReader",
+    "PdfFileReader",
+    "PdfFileWriter",
+    "PdfObject",
+    "PdfName",
+    "PdfArray",
+    "PdfTokens",
+    "PdfParseError",
+    "PdfDict",
+    "IndirectPdfDict",
+    "PdfString",
+    "PageMerge",
+]
+
+__version__ = pdfrw._version.__version__

--- a/pdfrw/buildxobj.py
+++ b/pdfrw/buildxobj.py
@@ -36,7 +36,7 @@ from .py23_diffs import iteritems
 from .uncompress import uncompress
 
 
-class ViewInfo(object):
+class ViewInfo:
     '''Instantiate ViewInfo with a uri, and it will parse out
     the filename, page, and viewrect into object attributes.
 
@@ -282,7 +282,7 @@ def _get_subpage(contents, resources, mbox):
     )
 
 
-def pagexobj(page, viewinfo=ViewInfo(), allow_compressed=True):
+def pagexobj(page, viewinfo=ViewInfo(), allow_compressed=True):  # noqa: B008
     '''pagexobj creates and returns a Form XObject for
     a given view within a page (Defaults to entire page.)
 
@@ -332,7 +332,7 @@ def docxobj(pageinfo, doc=None, allow_compressed=True):
     return pagexobj(sourcepage, pageinfo, allow_compressed)
 
 
-class CacheXObj(object):
+class CacheXObj:
     '''Use to keep from reparsing files over and over,
     and to keep from making the output too much
     bigger than it ought to be by replicating

--- a/pdfrw/buildxobj.py
+++ b/pdfrw/buildxobj.py
@@ -29,7 +29,7 @@ Reference for content:   Adobe PDF reference, sixth edition, version 1.7
 '''
 
 from .compress import compress
-from .errors import PdfNotImplementedError, log
+from .errors import PdfNotImplementedError, assert_eq, assert_none, log
 from .objects import PdfArray, PdfDict, PdfName
 from .pdfreader import PdfReader
 from .py23_diffs import iteritems
@@ -85,15 +85,16 @@ class ViewInfo(object):
             key = key.strip()
             value = value.replace(',', ' ').split()
             if key in ('page', 'rotate'):
-                assert len(value) == 1
+                assert_eq(len(value), 1)
                 setattr(self, key, int(value[0]))
             elif key == 'viewrect':
-                assert len(value) == 4
+                assert_eq(len(value), 4)
                 setattr(self, key, [float(x) for x in value])
             else:
                 log.error('Unknown option: %s', key)
         for key, value in iteritems(kw):
-            assert hasattr(self, key), key
+            if not hasattr(self, key):
+                raise AssertionError(key)
             setattr(self, key, value)
 
 
@@ -143,8 +144,8 @@ def getrects(inheritable, pageinfo, rotation):
     the desired pageinfo rectangle, return the page's
     media box and the calculated boundary (clip) box.
     '''
-    mbox = tuple([float(x) for x in inheritable.MediaBox])
-    cbox = tuple([float(x) for x in (inheritable.CropBox or mbox)])
+    mbox = tuple(float(x) for x in inheritable.MediaBox)
+    cbox = tuple(float(x) for x in inheritable.CropBox or mbox)
     vrect = pageinfo.viewrect
     if vrect is not None:
         # Rotate the media box to match what the user sees,
@@ -214,7 +215,7 @@ def _build_cache(contents, allow_compressed):
     if len(array) > 1:
         newstream = '\n'.join(x.stream for x in array)
         newlength = sum(int(x.Length) for x in array) + len(array) - 1
-        assert newlength == len(newstream)
+        assert_eq(newlength, len(newstream))
         xobj_copy.stream = newstream
         if was_compressed and allow_compressed:
             compress(xobj_copy)
@@ -318,13 +319,14 @@ def docxobj(pageinfo, doc=None, allow_compressed=True):
     # If no implicit or explicit doc, then read one in
     # from the filename.
     if doc is not None:
-        assert pageinfo.doc is None
+        assert_none(pageinfo.doc)
         pageinfo.doc = doc
     elif pageinfo.doc is not None:
         doc = pageinfo.doc
     else:
         doc = pageinfo.doc = PdfReader(pageinfo.docname, decompress=not allow_compressed)
-    assert isinstance(doc, PdfReader)
+    if not isinstance(doc, PdfReader):
+        raise AssertionError
 
     sourcepage = doc.pages[(pageinfo.page or 1) - 1]
     return pagexobj(sourcepage, pageinfo, allow_compressed)

--- a/pdfrw/crypt.py
+++ b/pdfrw/crypt.py
@@ -32,7 +32,7 @@ def create_key(password, doc):
     """Create an encryption key (Algorithm 2 in PDF spec)."""
     key_size = int(doc.Encrypt.Length or 40) // 8
     padded_pass = (password + _PASSWORD_PAD)[:32]
-    hasher = hashlib.blake2b()
+    hasher = hashlib.md5()  # nosec
     hasher.update(padded_pass)
     hasher.update(doc.Encrypt.O.to_bytes())
     hasher.update(struct.pack('<i', int(doc.Encrypt.P)))
@@ -41,7 +41,7 @@ def create_key(password, doc):
 
     if int(doc.Encrypt.R or 0) >= 3:
         for _ in range(50):
-            temp_hash = hashlib.blake2b(temp_hash[:key_size]).digest()
+            temp_hash = hashlib.md5(temp_hash[:key_size]).digest()  # nosec
 
     return temp_hash[:key_size]
 
@@ -53,7 +53,7 @@ def create_user_hash(key, doc):
         cipher = ARC4.new(key)  # nosec
         return cipher.encrypt(_PASSWORD_PAD)
     else:
-        hasher = hashlib.blake2b()
+        hasher = hashlib.md5()  # nosec
         hasher.update(_PASSWORD_PAD)
         hasher.update(doc.ID[0].to_bytes())
         temp_hash = hasher.digest()
@@ -88,7 +88,7 @@ class AESCryptFilter(object):
         key_extension += struct.pack('<i', gen)[:2]
         key_extension += 'sAlT'
         temp_key = self._key + key_extension
-        temp_key = hashlib.blake2b(temp_key).digest()
+        temp_key = hashlib.md5(temp_key).digest()  # nosec
 
         iv = data[: AES.block_size]
         cipher = AES.new(temp_key, AES.MODE_CBC, iv)
@@ -112,7 +112,7 @@ class RC4CryptFilter(object):
         key_extension = struct.pack('<i', num)[:3]
         key_extension += struct.pack('<i', gen)[:2]
         temp_key = self._key + key_extension
-        temp_key = hashlib.blake2b(temp_key).digest()[:new_key_size]
+        temp_key = hashlib.md5(temp_key).digest()[:new_key_size]  # nosec
 
         cipher = ARC4.new(temp_key)  # nosec
         return cipher.decrypt(data)

--- a/pdfrw/errors.py
+++ b/pdfrw/errors.py
@@ -38,3 +38,56 @@ class PdfOutputError(PdfError):
 
 class PdfNotImplementedError(PdfError):
     "Error thrown on missing features"
+
+
+def assert_eq(something, otherthing):
+    """
+    Assertion equality helper to replace legacy code.
+    """
+    if not something == otherthing:
+        raise AssertionError(f'Assert {something} eq {otherthing} failed')
+
+
+def assert_none(something):
+    """
+    Assertion none helper to replace legacy code.
+    """
+    if something is None:
+        return
+    raise AssertionError(f'Assert {something} is None failed')
+
+
+def assert_not(something):
+    """
+    Assertion not helper to replace legacy code.
+    """
+    if not something:
+        return
+    raise AssertionError(f'Assert not {something} failed')
+
+
+def assert_notin(something, otherthing):
+    """
+    Assertion not in helper to replace legacy code.
+    """
+    if something not in otherthing:
+        return
+    raise AssertionError(f'Assert {something} not in {otherthing} failed')
+
+
+def assert_notnone(something):
+    """
+    Assertion none helper to replace legacy code.
+    """
+    if something is not None:
+        return
+    raise AssertionError(f'Assert {something} is not None failed')
+
+
+def assert_range(something, lower=1, upper=16):
+    """
+    Assertion in range helper to replace legacy code.
+    """
+    if lower <= something <= upper:
+        return
+    raise AssertionError(f'Assert {something} in range {lower} - {upper} failed')

--- a/pdfrw/findobjs.py
+++ b/pdfrw/findobjs.py
@@ -125,7 +125,7 @@ def page_per_xobj(
     width=8.5 * 72,
     margin=0.0 * 72,
     image_only=False,
-    ignore=trivial_xobjs(),
+    ignore=trivial_xobjs(),  # noqa: B008
     wrap_object=wrap_object,
 ):
     '''page_per_xobj wraps every XObj found
@@ -134,7 +134,7 @@ def page_per_xobj(
     '''
     try:
         iter(margin)
-    except:
+    except TypeError:
         margin = [margin]
     while len(margin) < 4:
         margin *= 2

--- a/pdfrw/objects/__init__.py
+++ b/pdfrw/objects/__init__.py
@@ -15,5 +15,12 @@ from .pdfname import PdfName
 from .pdfobject import PdfObject
 from .pdfstring import PdfString
 
-__all__ = """PdfName PdfDict IndirectPdfDict PdfArray
-             PdfObject PdfString PdfIndirect""".split()
+__all__ = [
+    "PdfName",
+    "PdfDict",
+    "IndirectPdfDict",
+    "PdfArray",
+    "PdfObject",
+    "PdfString",
+    "PdfIndirect",
+]

--- a/pdfrw/objects/pdfarray.py
+++ b/pdfrw/objects/pdfarray.py
@@ -14,10 +14,11 @@ class PdfArray(list):
     '''A PdfArray maps the PDF file array object into a Python list.
     It has an indirect attribute which defaults to False.
     '''
-
+    _null_pdf = PdfObject('null')
+    _source = []
     indirect = False
 
-    def __init__(self, source=[]):
+    def __init__(self, source=_source):
         self._resolve = self._resolver
         self.extend(source)
 
@@ -28,7 +29,7 @@ class PdfArray(list):
         listiter=list.__iter__,
         PdfIndirect=PdfIndirect,
         resolved=_resolved,
-        PdfNull=PdfObject('null'),
+        PdfNull=_null_pdf,
     ):
         for index, value in enumerate(list.__iter__(self)):
             if isinstance(value, PdfIndirect):

--- a/pdfrw/objects/pdfdict.py
+++ b/pdfrw/objects/pdfdict.py
@@ -190,7 +190,7 @@ class PdfDict(dict):
         return list(self.iteritems())
 
     def itervalues(self):
-        for key, value in self.iteritems():
+        for _key, value in self.iteritems():
             yield value
 
     def values(self):
@@ -200,7 +200,7 @@ class PdfDict(dict):
         return list((key for key, value in self.iteritems()))
 
     def __iter__(self):
-        for key, value in self.iteritems():
+        for key, _value in self.iteritems():
             yield key
 
     def iterkeys(self):

--- a/pdfrw/objects/pdfdict.py
+++ b/pdfrw/objects/pdfdict.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2006-2015 Patrick Maupin, Austin, Texas
 # MIT license -- See LICENSE.txt for details
 
-from ..errors import PdfParseError
+from ..errors import PdfParseError, assert_notin
 from ..py23_diffs import iteritems
 from .pdfindirect import PdfIndirect
 from .pdfname import BasePdfName, PdfName
@@ -26,7 +26,7 @@ class _DictSearch(object):
             if value is not None:
                 return value
             myid = id(mydict)
-            assert myid not in visited
+            assert_notin(myid, visited)
             visited.add(myid)
             mydict = mydict.Parent
             if mydict is None:

--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -266,7 +266,6 @@ an encoder and decoder for PDFDocEncoding with the codecs module.
 
 import binascii
 import codecs
-import itertools
 import re
 
 from ..py23_diffs import convert_load, convert_store
@@ -579,7 +578,7 @@ class PdfString(str):
         return cls.from_bytes(raw, encoding)
 
     @classmethod
-    def encode(cls, source, uni_type=type(''), isinstance=isinstance):
+    def encode(cls, source, uni_type=str, isinstance=isinstance):
         """The encode() constructor is a legacy function that is
         also a convenience for the PdfWriter.
         """

--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -379,7 +379,7 @@ class PdfString(str):
 
     # Used by decode_literal; filled in on first use
 
-    unescape_dict = None
+    unescape_dict = {}
     unescape_func = None
 
     @classmethod
@@ -472,14 +472,14 @@ class PdfString(str):
     decode = to_unicode
 
     # Internal value used by encoding
-
     escape_splitter = None  # Calculated on first use
 
     @classmethod
     def init_escapes(cls):
         """Initialize the escape_splitter for the encode method"""
-        cls.escape_splitter = re.compile(br'(\(|\\|\))').split
-        return cls.escape_splitter
+        escape_splitter = re.compile(br'(\(|\\|\))').split
+        cls.escape_splitter = escape_splitter
+        return escape_splitter
 
     @classmethod
     def from_bytes(cls, raw, bytes_encoding='auto'):
@@ -510,7 +510,7 @@ class PdfString(str):
         if not force_hex:
             if bytes_encoding not in ('literal', 'auto'):
                 raise ValueError('Invalid bytes_encoding value: %s' % bytes_encoding)
-            splitlist = (cls.escape_splitter or cls.init_escapes())(raw)
+            splitlist = cls.init_escapes()(raw)
             if bytes_encoding == 'auto' and len(splitlist) // 2 >= len(raw):
                 force_hex = True
 
@@ -579,7 +579,7 @@ class PdfString(str):
         return cls.from_bytes(raw, encoding)
 
     @classmethod
-    def encode(cls, source, uni_type=type(u''), isinstance=isinstance):
+    def encode(cls, source, uni_type=type(''), isinstance=isinstance):
         """The encode() constructor is a legacy function that is
         also a convenience for the PdfWriter.
         """

--- a/pdfrw/pagemerge.py
+++ b/pdfrw/pagemerge.py
@@ -32,6 +32,8 @@ class RectXObj(PdfDict):
     and call the scale function.
     '''
 
+    grid_set = set('x y w h'.split())
+
     def __init__(self, page, viewinfo=NullInfo, **kw):
         '''The page is a page returned by PdfReader.  It will be
         turned into a cached Form XObject (so that multiple
@@ -85,7 +87,11 @@ class RectXObj(PdfDict):
         return self._rect[3]
 
     def __setattr__(
-        self, name, value, next=PdfDict.__setattr__, mine=set('x y w h'.split())
+        self,
+        name,
+        value,
+        next=PdfDict.__setattr__,
+        mine=grid_set,
     ):
         '''The underlying __setitem__ won't let us use a property
         setter, so we have to fake one.
@@ -158,8 +164,8 @@ class PageMerge(list):
     def __add__(self, other):
         if isinstance(other, dict):
             other = [other]
-        for other in other:
-            self.add(other)
+        for item in other:
+            self.add(item)
         return self
 
     def add(self, obj, prepend=False, **kw):

--- a/pdfrw/pdfwriter.py
+++ b/pdfrw/pdfwriter.py
@@ -18,7 +18,7 @@ tree/forest of PDF objects.
 import gc
 
 from .compress import compress as do_compress
-from .errors import PdfOutputError, log
+from .errors import PdfOutputError, assert_eq, assert_notnone, log
 from .objects import (
     IndirectPdfDict,
     PdfArray,
@@ -225,7 +225,7 @@ def FormatObjects(
     ).get
 
     for objid in killobj:
-        assert swapobj(objid) is not None
+        assert_notnone(swapobj(objid))
 
     # The first format of trailer gets all the information,
     # but we throw away the actual trailer formatting.
@@ -286,7 +286,7 @@ class PdfWriter(object):
                 pass
             else:
                 if version != '1.3':
-                    assert compress == False
+                    assert_eq(compress, False)
                     compress = version
                 version = fname
                 fname = None

--- a/pdfrw/pdfwriter.py
+++ b/pdfrw/pdfwriter.py
@@ -32,6 +32,7 @@ from .py23_diffs import convert_store, iteritems
 NullObject = PdfObject('null')
 NullObject.indirect = True
 NullObject.Type = 'Null object'
+STR_TYPES = tuple([type(''), type(b'')])
 
 
 def user_fmt(
@@ -39,7 +40,7 @@ def user_fmt(
     isinstance=isinstance,
     float=float,
     str=str,
-    basestring=(type(u''), type(b'')),
+    basestring=STR_TYPES,
     encode=PdfString.encode,
 ):
     '''This function may be replaced by the user for

--- a/pdfrw/py23_diffs.py
+++ b/pdfrw/py23_diffs.py
@@ -2,6 +2,8 @@
 # Copyright (C) 2006-2015 Patrick Maupin, Austin, Texas
 # MIT license -- See LICENSE.txt for details
 
+# flake8: noqa
+
 # Deal with Python2/3 differences
 
 try:

--- a/pdfrw/toreportlab.py
+++ b/pdfrw/toreportlab.py
@@ -107,7 +107,8 @@ def _makearray(rldoc, pdfobj):
 
 
 def _makestr(rldoc, pdfobj):
-    assert isinstance(pdfobj, (float, int, str)), repr(pdfobj)
+    if not isinstance(pdfobj, (float, int, str)):
+        raise AssertionError(repr(pdfobj))
     # TODO: Add fix for float like in pdfwriter
     value = str(getattr(pdfobj, 'encoded', None) or pdfobj)
     try:

--- a/pdfrw/uncompress.py
+++ b/pdfrw/uncompress.py
@@ -33,12 +33,13 @@ def streamobjects(mylist, isinstance=isinstance, PdfDict=PdfDict):
 
 # Hack so we can import if zlib not available
 decompressobj = zlib if zlib is None else zlib.decompressobj
+warnempty = set()
 
 
 def uncompress(
     mylist,
     leave_raw=False,
-    warnings=set(),
+    warnings=warnempty,
     flate=PdfName.FlateDecode,
     decompress=decompressobj,
     isinstance=isinstance,
@@ -104,9 +105,11 @@ def flate_png_impl(data, predictor=1, columns=1, colors=1, bpc=8):
     # https://www.w3.org/TR/2003/REC-PNG-20031110/#9Filters
     # Reconstruction functions
     # x: the byte being filtered;
-    # a: the byte corresponding to x in the pixel immediately before the pixel containing x (or the byte immediately before x, when the bit depth is less than 8);
+    # a: the byte corresponding to x in the pixel immediately before the pixel
+    #    containing x (or the byte immediately before x, when the bit depth is less than 8);
     # b: the byte corresponding to x in the previous scanline;
-    # c: the byte corresponding to b in the pixel immediately before the pixel containing b (or the byte immediately before b, when the bit depth is less than 8).
+    # c: the byte corresponding to b in the pixel immediately before the pixel
+    #    containing b (or the byte immediately before b, when the bit depth is less than 8).
 
     def subfilter(data, prior_row_data, start, length, pixel_size):
         # filter type 1: Sub

--- a/pdfrw/uncompress.py
+++ b/pdfrw/uncompress.py
@@ -14,7 +14,7 @@ probably an excellent source of additional filters.
 import array
 import math
 
-from .errors import log
+from .errors import assert_eq, assert_not, log
 from .objects import PdfArray, PdfDict, PdfName
 from .py23_diffs import (
     convert_load,
@@ -86,7 +86,7 @@ def uncompress(
                     elif predictor != 1:
                         error = 'Unsupported flatedecode predictor %s' % repr(predictor)
             if error is None:
-                assert not dco.unconsumed_tail
+                assert_not(dco.unconsumed_tail)
                 if dco.unused_data.strip():
                     error = 'Unconsumed compression data: %s' % repr(dco.unused_data[:20])
             if error is None:
@@ -159,7 +159,8 @@ def flate_png_impl(data, predictor=1, columns=1, colors=1, bpc=8):
     if predictor == 15:
         padding = (rowlen - len(data)) % rowlen
         data.extend([0] * padding)
-    assert len(data) % rowlen == 0
+    avalue = len(data) % rowlen
+    assert_eq(avalue, 0)
 
     rows = xrange(0, len(data), rowlen)
     prior_row_data = [0 for i in xrange(columnbytes)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,4 +75,3 @@ file = "pdfrw/_version.py"
 
 [tool.bandit]
 exclude_dirs = ["docs"]
-#skips = ["B603", "B404"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 # Application dependencies
 # These dependencies should be fixed in future
 #pycrypto>=2.6.1
-pycryptodome>=3.9.0
+pycryptodomex>=3.9.0
 reportlab>=3.5.46
 Pillow>=6.2.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@
 # Application dependencies
 # These dependencies should be fixed in future
 #pycrypto>=2.6.1
-pycryptodome>=3.9.0
+pycryptodomex>=3.9.0
 reportlab>=3.5.46
 Pillow>=6.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ zip_safe = True
 # unless dealing with encrypted or reportlab-generated PDFs, or
 # converting images
 rpt =
-    pycryptodome >= 3.9.0
+    pycryptodomex >= 3.9.0
     reportlab >= 3.5.46
     Pillow >= 6.2.2
 test =

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,4 +80,8 @@ exclude =
     docs,
     tests
 
-max-line-length = 90
+ignore =
+    # Black conflict
+    W503, E203
+
+max-line-length = 92

--- a/tests/test_assert_helpers.py
+++ b/tests/test_assert_helpers.py
@@ -1,0 +1,79 @@
+#! /usr/bin/env python
+# A part of forked pdfrw
+# Copyright (C) 2022 Stephen Arnold <nerdboy@gentoo.org>
+# MIT license -- See LICENSE.txt for details
+
+'''
+Run from the directory above like so:
+python -m tests.test_assert_helpers
+'''
+
+import unittest
+
+from pdfrw.errors import (
+    assert_eq,
+    assert_none,
+    assert_not,
+    assert_notin,
+    assert_notnone,
+    assert_range,
+)
+
+import pytest
+
+
+class TestAsserts(unittest.TestCase):
+    str_var = 'fubar'
+    int_var = 42
+    none_var = None
+
+    def test_assert_eq(self):
+        self.assertEqual(self.str_var, 'fubar')
+        assert_eq(self.str_var, 'fubar')
+
+    def test_assert_eq_raises(self):
+        some_string = 'ouch'
+        with pytest.raises(AssertionError):
+            assert_eq(self.str_var, some_string)
+
+    def test_assert_none(self):
+        assert_none(self.none_var)
+
+    def test_assert_none_raises(self):
+        some_string = 'ouch'
+        with pytest.raises(AssertionError):
+            assert_none(some_string)
+
+    def test_assert_not(self):
+        assert_not(self.none_var)
+
+    def test_assert_not_raises(self):
+        some_string = 'ouch'
+        with pytest.raises(AssertionError):
+            assert_not(some_string)
+
+    def test_assert_notin(self):
+        assert_notin('baz', self.str_var)
+
+    def test_assert_notin_raises(self):
+        some_string = 'ouch'
+        with pytest.raises(AssertionError):
+            assert_notin('ch', some_string)
+
+    def test_assert_notnone(self):
+        assert_notnone(self.int_var)
+
+    def test_assert_notnone_raises(self):
+        with pytest.raises(AssertionError):
+            assert_notnone(self.none_var)
+
+    def test_assert_range(self):
+        assert_range(self.int_var, 1, 50)
+
+    def test_assert_range_raises(self):
+        with pytest.raises(AssertionError):
+            assert_range(self.int_var, 1, 25)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -191,9 +191,5 @@ class TestOnePdf(unittest.TestCase):
                      scrub=True)
 
 
-def main():
-    unittest.main()
-
-
 if __name__ == '__main__':
-    main()
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -208,6 +208,24 @@ deps =
 commands =
     python -m isort pdfrw/
 
+[testenv:sec]
+skip_install = true
+passenv =
+    PYTHON
+    CI
+    OS
+    PYTHONIOENCODING
+    PIP_DOWNLOAD_CACHE
+
+allowlist_externals = bash
+
+deps =
+    {[base]deps}
+    bandit
+
+commands =
+    bandit -r pdfrw/
+
 [testenv:clean]
 skip_install = true
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -150,7 +150,6 @@ deps =
 
 commands_pre =
     python -m pip install -U pip
-    pip uninstall -y pdfrw
     pip install pdfrw[rpt] --pre -f dist/
 
 commands =


### PR DESCRIPTION
* add assertion error handlers to errors.py, replace raw asserts
* cleanup bandit warnings, add # nosec comments for not-issues
* replace pycrypto with pycryptodome, replace md5 with blake2b but keep/comment ARC4 for now (legacy PDF RC4 cipher)
* cleanup more pylint warnings, fix readme links
