### PR TITLE
Fix invalid escape sequences

### DIFF
--- a/pdfrw/objects/pdfstring.py
+++ b/pdfrw/objects/pdfstring.py
@@ -3,7 +3,7 @@
 #                    2016 James Laird-Wah, Sydney, Australia
 # MIT license -- See LICENSE.txt for details
 
-"""
+r"""
 
 ================================
 PdfString encoding and decoding
@@ -404,7 +404,7 @@ class PdfString(str):
         return unescape_func
 
     def decode_literal(self):
-        """Decode a PDF literal string, which is enclosed in parentheses ()
+        r"""Decode a PDF literal string, which is enclosed in parentheses ()
 
         Many pdfrw users never decode strings, so defer creating
         data structures to do so until the first string is decoded.


### PR DESCRIPTION
Fixes SyntaxWarnings:

.../site-packages/pdfrw/objects/pdfstring.py:6: SyntaxWarning: invalid escape sequence '\('
.../site-packages/pdfrw/objects/pdfstring.py:367: SyntaxWarning: invalid escape sequence '\['

Fixes https://github.com/pmaupin/pdfrw/issues/170, replaces #8.